### PR TITLE
Add program ('prg') command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ These commands must be run when the running status is `STOPPED`.
 
 * `clk <src (0: internal, 1: external)> <freq (in decimal Hz)>` - Sets the system clock and frequency. Maximum frequency allowed is 133 MHz. Default is 100 MHz internal clock. External clock frequency input is GPIO pin 20.
 * `frq` - Measure and print system frequencies.
+* `prg` - Equivalent to disconnecting the Pico, holding down the "bootsel" button, and reconnecting the Pico. Places the Pico into firmware flashing mode; the PrawnDO serial port should disappear and the Pico should mount as a mass storage device.
 
 The basis of the functionality for this serial interface was developed by Carter Turnbaugh.
 

--- a/prawn_do/prawn_do.c
+++ b/prawn_do/prawn_do.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdint.h>
+#include "pico/bootrom.h"
 #include "pico/stdio.h"
 #include "pico/stdlib.h"
 #include "pico/multicore.h"
@@ -11,7 +12,6 @@
 #include "hardware/clocks.h"
 #include "hardware/pio.h"
 #include "hardware/structs/clocks.h"
-
 
 
 #include "prawn_do.pio.h"
@@ -698,6 +698,10 @@ int main(){
 		// Measure system frequencies
 		else if(strncmp(serial_buf, "frq", 3) == 0) {
 			measure_freqs();
+		}
+		// Reboot into programming mode
+		else if(strncmp(serial_buf, "prg", 3) == 0) {
+			reset_usb_boot(0, 0);
 		}
 		else{
 			fast_serial_printf("Invalid command: %s\r\n", serial_buf);


### PR DESCRIPTION
This PR adds a program command to reboot the Pi Pico into programming mode without requiring physical access.